### PR TITLE
Created adduser moderator command

### DIFF
--- a/commands/adduser.js
+++ b/commands/adduser.js
@@ -6,16 +6,16 @@ exports.run = async (client, message, cmd, args, level) => { // eslint-disable-l
     while (args.length > 0) {
 
         // user id in args has the form <@273421645828325377>, so strip of leading <@ and trailing >
-        let userId = args.shift().replace(/[<@>]/g, "");
+        const userId = args.shift().replace(/[<@>]/g, "");
 
-        let user = message.guild.members.get(userId);
+        const user = message.guild.members.get(userId);
         if (!user) return message.reply(`User ${userId} not found.`).then(client.cmdError(message,cmd));
         if (!args[0]) return message.reply(`You didn't provide a swgoh.gg username for ${user}.`).then(client.cmdError(message,cmd)); 
 
         let swName = args.shift();
         if (swName.startsWith("~")) swName = swName.replace("~", "");
 
-        let id = client.profileTable.get(user.id);
+        const id = client.profileTable.get(user.id);
 
         if (!id) {
             client.profileTable.set(user.id, swName);

--- a/commands/adduser.js
+++ b/commands/adduser.js
@@ -1,0 +1,43 @@
+exports.run = async (client, message, cmd, args, level) => { // eslint-disable-line no-unused-vars
+
+   // Return and send error message if there are not 2 args
+   if (args.length < 2) return client.cmdError(message, cmd);
+
+    while (args.length > 0) {
+
+        // user id in args has the form <@273421645828325377>, so strip of leading <@ and trailing >
+        let userId = args.shift().replace(/[<@>]/g, "");
+
+        let user = message.guild.members.get(userId);
+        if (!user) return message.reply(`User ${userId} not found.`).then(client.cmdError(message,cmd));
+        if (!args[0]) return message.reply(`You didn't provide a swgoh.gg username for ${user}.`).then(client.cmdError(message,cmd)); 
+
+        let swName = args.shift();
+        if (swName.startsWith("~")) swName = swName.replace("~", "");
+
+        let id = client.profileTable.get(user.id);
+
+        if (!id) {
+            client.profileTable.set(user.id, swName);
+            message.reply(`I've added **${swName}** to ${user}'s record.`);
+        } else {
+            client.profileTable.set(user.id, swName);
+            message.reply(`I've changed ${user}'s record from **${id}** to **${swName}**.`);
+        }
+    }
+};
+
+exports.conf = {
+    enabled: true,
+    guildOnly: true,
+    aliases: ["au", "addusers"],
+    permLevel: "Moderator"
+};
+
+exports.help = {
+    name: "adduser",
+    category: "Moderator",
+	description: "Add the swgoh.gg username for one or more Discord users to the database",
+	usage: "adduser <discord-username> <swgoh.gg-username> [discord-username> <swgoh.gg-username>]",
+    examples: ["adduser @necavit necavit", "adduser @kyloren sweetsaberdude @hoboyoda theGhost"]
+};


### PR DESCRIPTION
I have a spreadsheet with my guild members' discord IDs and swgoh.,gg names and want to be able to add them all. This command accepts one or more `<discord ID> <swgoh.gg ID>` pairs and adds or updates records in the same manner as the add command. 

I set the category to Moderator (which is new) since it was game-related, rather than system-related, but was not for normal users.

If there are any best practices I should be applying in the code, let me know. 