### PR TITLE
Add newline-to-space replacement in argument parser.

### DIFF
--- a/events/message.js
+++ b/events/message.js
@@ -24,8 +24,8 @@ module.exports = (client, message) => {
 
     if (message.content.indexOf(settings.prefix) !== 0 && message.content.indexOf(client.user) !== 0) return; // Check for prefix or bot mention
 
-    let args = message.content.slice(settings.prefix.length).trim().split(/ +/g);
-    if (message.content.indexOf(client.user) == 0) args = message.content.slice(client.user.toString().length).trim().split(/ +/g);
+    let args = message.content.slice(settings.prefix.length).trim().replace(/\n+/g," ").split(/ +/g);
+    if (message.content.indexOf(client.user) == 0) args = message.content.slice(client.user.toString().length).trim().replace(/n+/g," ").split(/ +/g);
     const command = args.shift().toLowerCase();
 
     const level = client.permlevel(message); // Gets the user's permission level


### PR DESCRIPTION
This allows the user to paste `adduser` arguments from two-column spreadsheet list of `<discord ID> <swgoh ID>` pairs.

Example:
```
\addusers @RookieGunner    rookiegunner
@GeneralLawless    generallawless
```