### PR TITLE
nickname handling fix

### DIFF
--- a/commands/adduser.js
+++ b/commands/adduser.js
@@ -6,7 +6,7 @@ exports.run = async (client, message, cmd, args, level) => { // eslint-disable-l
     while (args.length > 0) {
 
         // user id in args has the form <@273421645828325377>, so strip of leading <@ and trailing >
-        const userId = args.shift().replace(/[<@>]/g, "");
+        const userId = args.shift().replace(/(^<@[!]?)|(>$)/g, "");
 
         const user = message.guild.members.get(userId);
         if (!user) return message.reply(`user ${userId} not found.`).then(client.cmdError(message,cmd));


### PR DESCRIPTION
When using a username (no nick), e.g. `@RookieGunner#3215` or a user ID, e.g. `<@273421645828325377>`, the args come in like this:
```[ '<@273421645828325377>', 'rookiegunner' ]```
But if the user has a nickname, the userid has an `!` added before the number:
```[ '<@!273421645828325377>', 'rookiegunner' ]```

this commit modifies the argument processing to handle this condition.